### PR TITLE
Flush the TX FIFO also after single byte writes

### DIFF
--- a/src/spi_host/rtl/spi_host_fsm.sv
+++ b/src/spi_host/rtl/spi_host_fsm.sv
@@ -487,7 +487,7 @@ module spi_host_fsm
   assign speed_o           = cmd_speed;
   assign sample_en_d       = byte_starting | shift_en_o;
   assign full_cyc_o        = full_cyc;
-  assign cmd_end_o         = ((byte_cntr_q == 'h1) & wr_en_o & ~rd_en_o & sr_wr_ready_i) || ((byte_cntr_q == 'h0) & rd_en_o & sr_rd_ready_i);
+  assign cmd_end_o         = (((byte_cntr_q == 'h1) || (new_command & (cmd_len == 'h0))) & wr_en_o & ~rd_en_o & sr_wr_ready_i) || ((byte_cntr_q == 'h0) & rd_en_o & sr_rd_ready_i);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin


### PR DESCRIPTION
Currently single byte writes are not working as intended as the TX FIFO is not flushed as it should. This change takes care of that edge case.