### PR TITLE
spi_host: Fix single byte writes

### DIFF
--- a/patches/spi_host/0004-vendor-Fix-single-byte-writes.patch
+++ b/patches/spi_host/0004-vendor-Fix-single-byte-writes.patch
@@ -1,0 +1,25 @@
+From 082a0860d0996e26dc812a4eba58ff11fdfff464 Mon Sep 17 00:00:00 2001
+From: Christopher Reinwardt <christopher.reinwardt@web.de>
+Date: Wed, 8 Feb 2023 00:36:21 +0100
+Subject: [PATCH] vendor Fix single byte writes
+
+---
+ rtl/spi_host_fsm.sv | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rtl/spi_host_fsm.sv b/rtl/spi_host_fsm.sv
+index e0106374e..005a77584 100644
+--- a/rtl/spi_host_fsm.sv
++++ b/rtl/spi_host_fsm.sv
+@@ -487,7 +487,7 @@ module spi_host_fsm
+   assign speed_o           = cmd_speed;
+   assign sample_en_d       = byte_starting | shift_en_o;
+   assign full_cyc_o        = full_cyc;
+-  assign cmd_end_o         = ((byte_cntr_q == 'h1) & wr_en_o & ~rd_en_o & sr_wr_ready_i) || ((byte_cntr_q == 'h0) & rd_en_o & sr_rd_ready_i);
++  assign cmd_end_o         = (((byte_cntr_q == 'h1) || (new_command & (cmd_len == 'h0))) & wr_en_o & ~rd_en_o & sr_wr_ready_i) || ((byte_cntr_q == 'h0) & rd_en_o & sr_rd_ready_i);
+ 
+   always_ff @(posedge clk_i or negedge rst_ni) begin
+     if (!rst_ni) begin
+-- 
+2.39.1
+

--- a/src/spi_host/rtl/spi_host_fsm.sv
+++ b/src/spi_host/rtl/spi_host_fsm.sv
@@ -487,7 +487,7 @@ module spi_host_fsm
   assign speed_o           = cmd_speed;
   assign sample_en_d       = byte_starting | shift_en_o;
   assign full_cyc_o        = full_cyc;
-  assign cmd_end_o         = ((byte_cntr_q == 'h1) & wr_en_o & ~rd_en_o & sr_wr_ready_i) || ((byte_cntr_q == 'h0) & rd_en_o & sr_rd_ready_i);
+  assign cmd_end_o         = (((byte_cntr_q == 'h1) || (new_command & (cmd_len == 'h0))) & wr_en_o & ~rd_en_o & sr_wr_ready_i) || ((byte_cntr_q == 'h0) & rd_en_o & sr_rd_ready_i);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin


### PR DESCRIPTION
Currently the TX FIFO is not flushed for single byte writes. This change fixes this edge case.