### PR TITLE
plic: Parameterize nonstandard extension registers

### DIFF
--- a/patches/rv_plic/tpl/data/0002-Parameterize-extension-registers.patch
+++ b/patches/rv_plic/tpl/data/0002-Parameterize-extension-registers.patch
@@ -1,0 +1,58 @@
+From 492453b1cc0dbd5fc5b7d33957c14d5808348060 Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Tue, 11 Apr 2023 17:46:57 +0200
+Subject: [PATCH] Parameterize extension registers
+
+---
+ rv_plic.hjson.tpl     | 6 +++---
+ rv_plic.tpldesc.hjson | 8 +++++++-
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/rv_plic.hjson.tpl b/rv_plic.hjson.tpl
+index 54e8437cc..e47b7922c 100644
+--- a/rv_plic.hjson.tpl
++++ b/rv_plic.hjson.tpl
+@@ -141,8 +141,8 @@
+              "excl:CsrNonInitTests:CsrExclCheck"],
+     }
+ % endfor
+-  { skipto: "0x4000000" }
+-% for i in range(target):
++  { skipto: "${hex(0x4000000 if nonstd_regs else 0x3FFFFF8)}" }
++% for i in range(target if nonstd_regs else 1):
+     { name: "MSIP${i}",
+       desc: '''msip for Hart ${i}.
+       Write 1 to here asserts software interrupt for Hart msip_o[${i}], write 0 to clear.''',
+@@ -155,7 +155,7 @@
+       ],
+     }
+ % endfor
+-  { skipto: "0x4004000" }
++  { skipto: "${hex(0x4004000 if nonstd_regs else 0x3FFFFFC)}" }
+   { name: "ALERT_TEST",
+       desc: '''Alert Test Register.''',
+       swaccess: "wo",
+diff --git a/rv_plic.tpldesc.hjson b/rv_plic.tpldesc.hjson
+index 37ec0798c..8ecfbc790 100644
+--- a/rv_plic.tpldesc.hjson
++++ b/rv_plic.tpldesc.hjson
+@@ -23,9 +23,15 @@
+     },
+     {
+       "name": "module_instance_name",
+-      "desc": instance name in case there are multiple rv_plic instances",
++      "desc": "instance name in case there are multiple rv_plic instances",
+       "type": "string",
+       "default": "rv_plic"
+     },
++    {
++      "name": "nonstd_regs",
++      "desc": "include nonstandard (OpenTitan) MSIP and alert regs (Requires > 64 MiB address space)",
++      "type": "int",
++      "default": 1
++    },
+   ],
+ }
+-- 
+2.16.5
+

--- a/patches/rv_plic/tpl/rtl/0002-Parameterize-extension-registers.patch
+++ b/patches/rv_plic/tpl/rtl/0002-Parameterize-extension-registers.patch
@@ -1,0 +1,40 @@
+From 145f6a3e85af6e03c9774735cc2dceca8e3c6518 Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Tue, 11 Apr 2023 17:47:43 +0200
+Subject: [PATCH] Parameterize extension registers
+
+---
+ rv_plic.sv.tpl | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/rv_plic.sv.tpl b/rv_plic.sv.tpl
+index 9ca2c15c5..5b72eea77 100644
+--- a/rv_plic.sv.tpl
++++ b/rv_plic.sv.tpl
+@@ -129,9 +129,13 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
+   ///////////////////
+   // MSIP register //
+   ///////////////////
++% if nonstd_regs:
+ % for t in range(target):
+   assign msip_o[${t}] = reg2hw.msip${t}.q;
+ % endfor
++% else:
++  assign msip_o = '0;
++% endif
+ 
+   ////////
+   // IP //
+@@ -217,7 +221,9 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
+ 
+   // Assertions
+   `ASSERT_KNOWN(IrqKnownO_A, irq_o)
++% if nonstd_regs:
+   `ASSERT_KNOWN(MsipKnownO_A, msip_o)
++% endif
+   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
+     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
+   end
+-- 
+2.16.5
+

--- a/src/rv_plic/tpl/rv_plic/data/rv_plic.hjson.tpl
+++ b/src/rv_plic/tpl/rv_plic/data/rv_plic.hjson.tpl
@@ -141,8 +141,8 @@
              "excl:CsrNonInitTests:CsrExclCheck"],
     }
 % endfor
-  { skipto: "0x4000000" }
-% for i in range(target):
+  { skipto: "${hex(0x4000000 if nonstd_regs else 0x3FFFFF8)}" }
+% for i in range(target if nonstd_regs else 1):
     { name: "MSIP${i}",
       desc: '''msip for Hart ${i}.
       Write 1 to here asserts software interrupt for Hart msip_o[${i}], write 0 to clear.''',
@@ -155,7 +155,7 @@
       ],
     }
 % endfor
-  { skipto: "0x4004000" }
+  { skipto: "${hex(0x4004000 if nonstd_regs else 0x3FFFFFC)}" }
   { name: "ALERT_TEST",
       desc: '''Alert Test Register.''',
       swaccess: "wo",

--- a/src/rv_plic/tpl/rv_plic/data/rv_plic.tpldesc.hjson
+++ b/src/rv_plic/tpl/rv_plic/data/rv_plic.tpldesc.hjson
@@ -23,9 +23,15 @@
     },
     {
       "name": "module_instance_name",
-      "desc": instance name in case there are multiple rv_plic instances",
+      "desc": "instance name in case there are multiple rv_plic instances",
       "type": "string",
       "default": "rv_plic"
+    },
+    {
+      "name": "nonstd_regs",
+      "desc": "include nonstandard (OpenTitan) MSIP and alert regs (Requires > 64 MiB address space)",
+      "type": "int",
+      "default": 1
     },
   ],
 }

--- a/src/rv_plic/tpl/rv_plic/rtl/rv_plic.sv.tpl
+++ b/src/rv_plic/tpl/rv_plic/rtl/rv_plic.sv.tpl
@@ -129,9 +129,13 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   ///////////////////
   // MSIP register //
   ///////////////////
+% if nonstd_regs:
 % for t in range(target):
   assign msip_o[${t}] = reg2hw.msip${t}.q;
 % endfor
+% else:
+  assign msip_o = '0;
+% endif
 
   ////////
   // IP //
@@ -217,7 +221,9 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
 
   // Assertions
   `ASSERT_KNOWN(IrqKnownO_A, irq_o)
+% if nonstd_regs:
   `ASSERT_KNOWN(MsipKnownO_A, msip_o)
+% endif
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end


### PR DESCRIPTION
This adds an IP parameter `nonstd_regs` to optionally move the additional non-RISC-V-conform registers (MSIPs and alerts) in the OpenTitan RISC-V PLIC to a reserved space. These cause decoding issues when the PLIC is provided with only its standard 64 MiB address space.

By default, these registers are *enabled*, making this a non-breaking change amenable to a minor release.