### PR TITLE
rv_plic: Correct enable reg context stride

### DIFF
--- a/patches/rv_plic/tpl/data/0003-Correct-enable-reg-context-stride.patch
+++ b/patches/rv_plic/tpl/data/0003-Correct-enable-reg-context-stride.patch
@@ -1,0 +1,25 @@
+From 3bb0083b7aa345ec431c847210a0bb12739995e4 Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Wed, 24 May 2023 17:48:34 +0200
+Subject: [PATCH] Correct enable reg context stride
+
+---
+ rv_plic.hjson.tpl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rv_plic.hjson.tpl b/rv_plic.hjson.tpl
+index e47b7922c..81e42a5d7 100644
+--- a/rv_plic.hjson.tpl
++++ b/rv_plic.hjson.tpl
+@@ -102,7 +102,7 @@
+       }
+     },
+ % for i in range(target):
+-    { skipto: "${"0x{:x}".format(0x00002000 + i * 0x100)}" }
++    { skipto: "${"0x{:x}".format(0x00002000 + i * 0x80)}" }
+     { multireg: {
+         name: "IE${i}",
+         desc: "Interrupt Enable for Target ${i}",
+-- 
+2.28.0
+

--- a/src/rv_plic/tpl/rv_plic/data/rv_plic.hjson.tpl
+++ b/src/rv_plic/tpl/rv_plic/data/rv_plic.hjson.tpl
@@ -102,7 +102,7 @@
       }
     },
 % for i in range(target):
-    { skipto: "${"0x{:x}".format(0x00002000 + i * 0x100)}" }
+    { skipto: "${"0x{:x}".format(0x00002000 + i * 0x80)}" }
     { multireg: {
         name: "IE${i}",
         desc: "Interrupt Enable for Target ${i}",


### PR DESCRIPTION
The upstream PLIC register layout upgraded to in v0.3.0 inexplicably changed the enable register context stride from `0x80` to `0x100`, which violates the PLIC spec and is incongruent with the RV PLIC Linux driver; this patch fixes that.